### PR TITLE
Add preserve_on_update field to sale schema meta

### DIFF
--- a/documentation/sale.md
+++ b/documentation/sale.md
@@ -15,7 +15,8 @@
 {
   "meta": {
     "document_type": "ameax_sale",
-    "schema_version": "1.0"
+    "schema_version": "1.0",
+    "preserve_on_update": ["description", "rating"]
   },
   "identifiers": {
     "external_id": "S234",
@@ -90,6 +91,7 @@
   - `"create_only"`: Only creates new records, ignores updates to existing ones
   - `"update_only"`: Only updates existing records, ignores new ones
   - `null`: Same as default behavior (`"create_or_update"`)
+- **`preserve_on_update`** *(nullable, array of strings)*: List of field names to preserve (not overwrite) when updating an existing record. Listed fields become optional in validation and are excluded from the update. Has no effect on record creation.
 
 #### **2. Identifiers** *(required, object)*
 - **`external_id`** *(required, string)*: A unique external identifier for the sales record.

--- a/schemas/ameax_sale.v1-0.schema.json
+++ b/schemas/ameax_sale.v1-0.schema.json
@@ -20,6 +20,13 @@
             "enum": ["create_or_update", "create_only", "update_only", null],
             "default": "create_or_update",
             "description": "Controls how records are processed during import. Defaults to create_or_update if not specified."
+          },
+          "preserve_on_update": {
+            "type": ["array", "null"],
+            "items": {
+              "type": "string"
+            },
+            "description": "List of field names to preserve (not overwrite) when updating an existing record. Listed fields become optional in validation and are excluded from the update. Has no effect on record creation."
           }
         }
       },


### PR DESCRIPTION
## Summary
- Add `preserve_on_update` property to `meta.properties` in `ameax_sale.v1-0.schema.json`
- Update documentation and example JSON in `documentation/sale.md`
- Documentation-only change — the `meta` object has no `additionalProperties: false`, so the feature works without this schema change

## Test plan
- [x] Verify JSON schema is valid
- [x] Verify existing documents still validate against the schema
- [x] Review documentation for correctness

Closes #1

🤖 Generated with [Claude Code](https://claude.com/claude-code)