### PR TITLE
Sync receipt status handling with server and API package

### DIFF
--- a/docs/review-findings-receipt-status.md
+++ b/docs/review-findings-receipt-status.md
@@ -1,0 +1,149 @@
+# Review Findings: Receipt Status & Dokumentation
+
+**Datum:** 2026-02-17
+**Scope:** `schemas/ameax_receipt.v1-0.schema.json`, `documentation/receipt.md`, `examples/ameax_receipt.json`
+**Status:** Nur Analyse — keine Änderungen, Entscheidungen hängen von Server-Projekt ab
+
+---
+
+## 1. Status-Vollständigkeit
+
+### 1.1 Schema-Enum vs. Dokumentation
+
+Das Schema definiert 13 Status-Werte (Zeile 39):
+
+| Status | Offer | Order | Invoice/CN/Cancel | Delivery Note | Doku vorhanden? |
+|---|---|---|---|---|---|
+| `draft` | ✅ | ✅ | ✅ | ✅ | ✅ |
+| `outstanding` | ✅ | | ✅ | ✅ | ✅ |
+| `accepted` | ✅ | | | | ✅ |
+| `obsolet` | ✅ | | | | ✅ |
+| `refused` | ✅ | | | | ✅ |
+| `in_progress` | | ✅ | | | ✅ |
+| `completed` | | ✅ | ✅ | ✅ | ✅ |
+| `cancelled` | | ✅ | | | ✅ |
+| `read_for_dispatch` | | | ✅ | | ✅ |
+| `on_hold` | | | ✅ | | ✅ |
+| **`outstanding_payment`** | | | ? | | ⚠️ **FEHLT** |
+| **`cancellation`** | | | ? | | ⚠️ **FEHLT** |
+| **`paused`** | | | ? | | ⚠️ **FEHLT** |
+
+### 1.2 Findings zu fehlenden Status
+
+- **`outstanding_payment`**: Im Schema vorhanden, in der Doku keinem Typ zugeordnet. Wird laut Analyse im Server-Plugin für Invoices verwendet, fehlt aber in `availableByType()` auf dem Server. **Abwarten, ob Server nachbessert — dann für Invoice-Typen dokumentieren.**
+- **`cancellation`**: Im Schema vorhanden, keinem Typ zugeordnet in der Doku. Klären: Welcher Typ nutzt diesen Status? Ist das ein Legacy-Wert?
+- **`paused`**: Im Schema vorhanden, keinem Typ zugeordnet in der Doku. Laut Server-Analyse ebenfalls keinem Typ zugeordnet. Klären: Soll `paused` entfernt werden oder einem Typ zugewiesen werden?
+
+---
+
+## 2. Deprecation-Hinweis für `pending`
+
+- **`pending` ist NICHT im Schema-Enum** — korrekt.
+- **`pending` ist NIRGENDS in der Dokumentation erwähnt** — ⚠️ problematisch.
+- `pending` war seit Juni 2025 der Default-Status im PHP API-Package (`ameax-json-import-api`). Bestehende Clients könnten diesen Wert noch senden.
+- Im API-Package (Branch `feature/receipt-status-expansion`) wird `pending` als `@deprecated` beibehalten.
+
+### Empfehlung
+
+Ein Abschnitt "Deprecated Values" sollte ergänzt werden, z.B.:
+
+> **Deprecated Status Values**
+>
+> | Value | Deprecated since | Hinweis |
+> |---|---|---|
+> | `pending` | v1.0 (2026-xx) | War der ursprüngliche Default-Status im API-Package. Wird serverseitig auf `draft` gemappt (Mapping-Entscheidung beim Server-Projekt abwarten). Neue Implementierungen sollten `draft` verwenden. |
+
+**Abhängigkeit:** Wie genau `pending` gemappt wird (→ `draft`?) muss im Server-Projekt entschieden werden.
+
+---
+
+## 3. Delivery Note (`deliverynote`)
+
+### Finding: Typ fehlt im Schema!
+
+- Die **Dokumentation** listet "Delivery Note" als Typ mit Status `draft`, `outstanding`, `completed` (Zeile 105).
+- Das **Schema** definiert als `type`-Enum nur: `offer`, `order`, `invoice`, `credit_note`, `cancellation_document` (Zeile 23).
+- **`deliverynote` (oder `delivery_note`) fehlt im Schema-Enum!**
+- Der Server kennt `deliverynote` als Typ.
+
+### Handlungsbedarf
+
+Entweder:
+1. `delivery_note` zum Schema-Enum hinzufügen (konsistent mit Snake-Case-Konvention der anderen Typen) — **Vorsicht:** Server verwendet `deliverynote` (ohne Underscore), Schema-Konvention wäre `delivery_note`.
+2. Oder Dokumentation korrigieren, falls Delivery Notes bewusst nicht über die API importiert werden sollen.
+
+**Klärung nötig:** Soll der Import-Typ `deliverynote` oder `delivery_note` heißen? Welche Konvention gilt?
+
+---
+
+## 4. Allgemeine Konsistenz-Findings
+
+### 4.1 ⚠️ Falscher Schema-Link in der Dokumentation
+
+`documentation/receipt.md`, Zeile 7:
+```markdown
+[View Schema File](../schemas/ameax_organization_account.v1-0.schema.json)
+```
+Verlinkt auf das **Organization-Schema** statt auf das Receipt-Schema. Muss sein:
+```markdown
+[View Schema File](../schemas/ameax_receipt.v1-0.schema.json)
+```
+
+### 4.2 ⚠️ `tax_type` Enum-Mismatch (Top-Level)
+
+- **Schema** (Zeile 41): `regular`, `reduced`, `exempt_eu`, `exempt_third`, `exempt_other`
+- **Dokumentation** (Zeile 107): `regular`, `reduced`, `exempt`
+
+Die Dokumentation zeigt die **Line-Item-Werte** statt der **Top-Level-Werte**. Die Top-Level-`tax_type` hat differenziertere Exempt-Kategorien.
+
+**Korrektur nötig:** Doku Zeile 107 muss die 5 Werte des Top-Level-Schemas zeigen.
+
+### 4.3 ⚠️ `import_status` nicht dokumentiert
+
+Das Schema definiert `meta.import_status` (Zeilen 16-19) als optionales Objekt mit `additionalProperties: true`. Dieses Feld wird in der Dokumentation nicht erwähnt.
+
+**Klären:** Ist `import_status` ein Response-Feld (vom Server befüllt) oder kann es beim Import mitgeschickt werden? Falls nur Response → ggf. im Schema als read-only kennzeichnen oder in der Doku als "wird vom Server befüllt" dokumentieren.
+
+### 4.4 `pursued_from.external_id` nicht dokumentiert
+
+- **Schema** (Zeilen 61-72): `pursued_from` unterstützt sowohl `receipt_number` als auch `external_id` (via `anyOf`).
+- **Dokumentation** (Zeilen 115-118): Erwähnt nur `type` und `receipt_number`, nicht `external_id`.
+
+**Korrektur nötig:** `external_id` als Alternative zu `receipt_number` dokumentieren.
+
+### 4.5 Inkonsistenz zwischen Dokumentations-Beispiel und Example-Datei
+
+- Doku-Beispiel (Zeile 28): `"sale_external_id": "SALE-2025-042"`
+- Example-Datei (Zeile 14): `"sale_external_id": "OP123"`
+
+Keine funktionale Auswirkung, aber sollte vereinheitlicht werden.
+
+### 4.6 `customer_external_id` — Status
+
+- **Schema:** Vorhanden (Zeile 38), inklusive `anyOf`-Constraint (Zeilen 137-140).
+- **Dokumentation:** Vorhanden und korrekt dokumentiert (Zeile 100), inklusive Hinweis auf Pflicht-Alternative.
+- **Befund: ✅ Korrekt dokumentiert.** Kein Handlungsbedarf.
+
+---
+
+## 5. Zusammenfassung der Handlungsbedarfe
+
+### Sofort umsetzbar (keine Server-Abhängigkeit)
+
+| # | Finding | Priorität |
+|---|---|---|
+| 4.1 | Schema-Link korrigieren (organization → receipt) | Hoch |
+| 4.2 | Top-Level `tax_type` Enum in Doku korrigieren | Hoch |
+| 4.4 | `pursued_from.external_id` dokumentieren | Mittel |
+| 4.5 | Example-Wert für `sale_external_id` vereinheitlichen | Niedrig |
+
+### Abhängig von Server-Entscheidungen
+
+| # | Finding | Abhängigkeit |
+|---|---|---|
+| 1.2 | `outstanding_payment` Typ-Zuordnung | Server: `availableByType()` für Invoices |
+| 1.2 | `cancellation` Typ-Zuordnung | Server: Klären, ob Legacy oder aktiv |
+| 1.2 | `paused` Typ-Zuordnung | Server: Keinem Typ zugeordnet |
+| 2 | `pending` Deprecation-Hinweis | Server: Mapping-Entscheidung (→ `draft`?) |
+| 3 | `delivery_note` Typ zum Schema hinzufügen | Server: Naming-Konvention klären |
+| 4.3 | `import_status` dokumentieren | Server: Zweck des Feldes klären |

--- a/documentation/receipt.md
+++ b/documentation/receipt.md
@@ -28,6 +28,7 @@
   "sale_external_id": "SALE-2025-042",
   "date": "2025-02-01",
   "customer_number": "12345",
+  "customer_external_id": "CUST-EXT-001",
   "status": "completed",
   "tax_mode": "net",
   "tax_type": "regular",
@@ -95,12 +96,17 @@
 - **`user_external_id`** *(nullable, string)*: External identifier of the user processing the receipt.
 - **`sale_external_id`** *(nullable, string)*: External identifier to link this receipt to a sales opportunity. **Note: When using this field, the corresponding sale record should be synchronized first to ensure proper linkage.**
 - **`date`** *(required, string, YYYY-MM-DD format)*: Date of the receipt creation.
-- **`customer_number`** *(required, string)*: Customer identifier to link the receipt to a specific customer.
+- **`customer_number`** *(optional, string or null)*: Customer number (`kundennr`) to link the receipt to a specific customer. **At least one of `customer_number` or `customer_external_id` must be provided.**
+- **`customer_external_id`** *(optional, string or null)*: External customer identifier (`customer_extern_id`) to link the receipt to a specific customer. Use this field when the customer was imported and has `kundennr` set to `0`. **At least one of `customer_number` or `customer_external_id` must be provided. When both are provided, `customer_number` takes precedence.**
 - **`status`** *(required, string)*: Current status of the receipt. The allowed values depend on the receipt type:
   - **Offer:** `draft`, `outstanding`, `accepted`, `obsolet`, `refused`
   - **Order:** `draft`, `in_progress`, `completed`, `cancelled`
-  - **Invoice, Credit Note, Cancellation Document:** `draft`, `read_for_dispatch`, `on_hold`, `outstanding`, `completed`
+  - **Invoice, Credit Note, Cancellation Document:** `draft`, `read_for_dispatch`, `on_hold`, `outstanding`, `outstanding_payment`, `completed`
   - **Delivery Note:** `draft`, `outstanding`, `completed`
+
+  > **Note:** The status `paused` exists in the schema enum but is currently not assigned to any receipt type. It will be rejected by server-side validation.
+
+  > **Deprecated:** The status `pending` is accepted for backward compatibility but will be automatically mapped to `in_progress` by the server before validation. New implementations should use the type-specific statuses listed above.
 - **`tax_mode`** *(required, string, allowed values: net, gross)*: Defines whether prices include tax or not.
 - **`tax_type`** *(required, string, allowed values: regular, reduced, exempt)*: Specifies the applicable tax type.
 

--- a/documentation/receipt.md
+++ b/documentation/receipt.md
@@ -4,7 +4,7 @@
 [View Example File](../examples/ameax_receipt.json)
 
 ## JSON Schema for validation
-[View Schema File](../schemas/ameax_organization_account.v1-0.schema.json)
+[View Schema File](../schemas/ameax_receipt.v1-0.schema.json)
 
 ### **JSON Structure: Receipt**
 

--- a/examples/ameax_receipt.json
+++ b/examples/ameax_receipt.json
@@ -14,6 +14,7 @@
   "sale_external_id": "OP123",
   "date": "2025-02-01",
   "customer_number": "12345",
+  "customer_external_id": "CUST-EXT-001",
   "status": "completed",
   "tax_mode": "net",
   "tax_type": "regular",

--- a/schemas/ameax_receipt.v1-0.schema.json
+++ b/schemas/ameax_receipt.v1-0.schema.json
@@ -34,8 +34,9 @@
     "user_external_id": { "type": ["string", "null"] },
     "sale_external_id": { "type": ["string", "null"] },
     "date": { "type": "string", "format": "date" },
-    "customer_number": { "type": "string" },
-    "status": { "type": "string", "enum": ["draft", "on_hold", "read_for_dispatch", "in_progress", "outstanding_payment", "completed", "cancellation", "outstanding", "obsolet", "refused", "accepted", "cancelled", "paused"] },
+    "customer_number": { "type": ["string", "null"] },
+    "customer_external_id": { "type": ["string", "null"] },
+    "status": { "type": "string", "enum": ["draft", "on_hold", "read_for_dispatch", "in_progress", "outstanding_payment", "completed", "cancellation", "outstanding", "obsolet", "refused", "accepted", "cancelled", "paused", "pending"] },
     "tax_mode": { "type": "string", "enum": ["net", "gross"] },
     "tax_type": { "type": "string", "enum": ["regular", "reduced", "exempt_eu", "exempt_third", "exempt_other"] },
     "subject": { "type": ["string", "null"] },
@@ -132,5 +133,9 @@
       "additionalProperties": true
     }
   },
-  "required": ["meta", "type", "identifiers", "date", "customer_number", "status", "tax_mode", "tax_type", "line_items"]
+  "required": ["meta", "type", "identifiers", "date", "status", "tax_mode", "tax_type", "line_items"],
+  "anyOf": [
+    { "required": ["customer_number"] },
+    { "required": ["customer_external_id"] }
+  ]
 }


### PR DESCRIPTION
## Summary

- Add `pending` as 14th value to receipt status enum (mapped to `in_progress` server-side for backward compatibility)
- Add `outstanding_payment` to allowed statuses for Invoice, Credit Note, and Cancellation Document in documentation
- Document deprecation of `pending` status and note that `paused` is in enum but unassigned
- Add `customer_external_id` as alternative identifier to `customer_number` (schema, docs, example)
- Make `customer_number` nullable with `anyOf` constraint requiring at least one of `customer_number` / `customer_external_id`
- Add review findings document listing remaining open issues (schema link, tax_type mismatch, deliverynote type, etc.)

Aligned with:
- **ameax Server** branch `feature/receipt-status-consistency` (commit ea707fa14)
- **ameax-json-import-api** branch `feature/receipt-status-expansion` (commit cefe313)

## Test plan

- [ ] Validate `schemas/ameax_receipt.v1-0.schema.json` against JSON Schema Draft-07
- [ ] Verify `examples/ameax_receipt.json` validates against updated schema
- [ ] Review status tables in `documentation/receipt.md` match server `availableByType()` mappings
- [ ] Review open findings in `docs/review-findings-receipt-status.md` for follow-up

🤖 Generated with [Claude Code](https://claude.com/claude-code)